### PR TITLE
[don't merge] Hacky way to simulate attempts of get_outs

### DIFF
--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1610,7 +1610,7 @@ private:
     bool is_spent(const transfer_details &td, bool strict = true) const;
     bool is_spent(size_t idx, bool strict = true) const;
     void get_outs(std::vector<std::vector<get_outs_entry>> &outs, const std::vector<size_t> &selected_transfers, size_t fake_outputs_count, bool rct);
-    void get_outs(std::vector<std::vector<get_outs_entry>> &outs, const std::vector<size_t> &selected_transfers, size_t fake_outputs_count, std::vector<uint64_t> &rct_offsets);
+    void get_outs(std::vector<std::vector<get_outs_entry>> &outs, const std::vector<size_t> &selected_transfers, size_t fake_outputs_count, std::vector<uint64_t> &rct_offsets, uint64_t &rct_start_height);
     bool tx_add_fake_output(std::vector<std::vector<tools::wallet2::get_outs_entry>> &outs, uint64_t global_index, const crypto::public_key& tx_public_key, const rct::key& mask, uint64_t real_index, bool unlocked) const;
     bool should_pick_a_second_output(bool use_rct, size_t n_transfers, const std::vector<size_t> &unused_transfers_indices, const std::vector<size_t> &unused_dust_indices) const;
     std::vector<size_t> get_only_rct(const std::vector<size_t> &unused_dust_indices, const std::vector<size_t> &unused_transfers_indices) const;


### PR DESCRIPTION
### Overview

The goal of this is to sanity check the gamma distribution the client's decoy selection algorithm produces by re-attempting `get_outs` a bunch of times. It's super hacky.

### How to run

First, make sure you're running a node, and pause it (I called the command `max_peers 0` so it would stop syncing with other nodes). Pausing it makes sure each run of `get_outs` will be consistent.

Second, make sure you have a mainnet wallet with a recent output, then run `monero-wallet-cli` and just attempt to make a transfer. It will run the simulation, and then automatically fail out of the transaction construction process and tell you to check the logs. Once complete, the logs will contain lines like the following:

```
2021-07-16 00:38:31.504	    7f963fe26a00	INFO	wallet.wallet2	src/wallet/wallet2.cpp:8167	Diff from current height: 1013, Frequency: 14
2021-07-16 00:38:31.504	    7f963fe26a00	INFO	wallet.wallet2	src/wallet/wallet2.cpp:8167	Diff from current height: 1014, Frequency: 210
2021-07-16 00:38:31.504	    7f963fe26a00	INFO	wallet.wallet2	src/wallet/wallet2.cpp:8167	Diff from current height: 1015, Frequency: 211
```

### What to do with the logs

There's probably a way easier way to do this and automate it, but I just copy pasted the logs into LibreOffice calc, used the built-in delimiter, parsed the height diff and frequency into 2 separate columns, then made a chart:

![get_outs 100k simulations results](https://user-images.githubusercontent.com/26468430/125879650-5be746af-a5b3-497f-a3ed-fe0b303fc656.png)
