### PR TITLE
multisig: fix segfault restoring encrypted multisig seed

### DIFF
--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -101,7 +101,7 @@ namespace cryptonote
     boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm, const cryptonote::account_public_address& address,
         const boost::optional<crypto::secret_key>& spendkey, const crypto::secret_key& viewkey);
     boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm,
-        const epee::wipeable_string &multisig_keys, const std::string &old_language);
+        const epee::wipeable_string &multisig_keys, const epee::wipeable_string &seed_pass, const std::string &old_language);
     boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm);
     boost::optional<epee::wipeable_string> open_wallet(const boost::program_options::variables_map& vm);
     bool close_wallet();


### PR DESCRIPTION
The segfault occurs [here](https://github.com/monero-project/monero/blob/5256fdd7a155f7543bd710e991d5dd407981b35a/src/wallet/wallet2.cpp#L13793) when trying to decrypt `multisig_keys` using the seed passphrase, because `m_kdf_rounds` doesn't get initialized until [`new_wallet` -> `tools::wallet2::make_new`](https://github.com/monero-project/monero/blob/5256fdd7a155f7543bd710e991d5dd407981b35a/src/simplewallet/simplewallet.cpp#L5063).

The solution in this PR is to hold off on decrypting the encrypted multisig seed until after `m_kdf_rounds` is initialized.