### PR TITLE
faster fe_reduce

### DIFF
--- a/src/crypto/crypto-ops.c
+++ b/src/crypto/crypto-ops.c
@@ -1328,16 +1328,9 @@ void ge_double_scalarmult_base_vartime_p3(ge_p3 *r3, const unsigned char *a, con
   }
 }
 
-/* From ge_frombytes.c, modified */
+/* From fe_frombytes.c */
 
-int ge_frombytes_vartime(ge_p3 *h, const unsigned char *s) {
-  fe u;
-  fe v;
-  fe vxx;
-  fe check;
-
-  /* From fe_frombytes.c */
-
+int fe_frombytes_vartime(fe y, const unsigned char *s) {
   int64_t h0 = load_4(s);
   int64_t h1 = load_3(s + 4) << 6;
   int64_t h2 = load_3(s + 7) << 5;
@@ -1378,18 +1371,31 @@ int ge_frombytes_vartime(ge_p3 *h, const unsigned char *s) {
   carry6 = (h6 + (int64_t) (1<<25)) >> 26; h7 += carry6; h6 -= carry6 << 26;
   carry8 = (h8 + (int64_t) (1<<25)) >> 26; h9 += carry8; h8 -= carry8 << 26;
 
-  h->Y[0] = h0;
-  h->Y[1] = h1;
-  h->Y[2] = h2;
-  h->Y[3] = h3;
-  h->Y[4] = h4;
-  h->Y[5] = h5;
-  h->Y[6] = h6;
-  h->Y[7] = h7;
-  h->Y[8] = h8;
-  h->Y[9] = h9;
+  y[0] = h0;
+  y[1] = h1;
+  y[2] = h2;
+  y[3] = h3;
+  y[4] = h4;
+  y[5] = h5;
+  y[6] = h6;
+  y[7] = h7;
+  y[8] = h8;
+  y[9] = h9;
 
-  /* End fe_frombytes.c */
+  return 0;
+}
+
+/* From ge_frombytes.c, modified */
+
+int ge_frombytes_vartime(ge_p3 *h, const unsigned char *s) {
+  fe u;
+  fe v;
+  fe vxx;
+  fe check;
+
+  if (fe_frombytes_vartime(h->Y, s) != 0) {
+    return -1;
+  }
 
   fe_1(h->Z);
   fe_sq(u, h->Y);

--- a/src/crypto/crypto-ops.c
+++ b/src/crypto/crypto-ops.c
@@ -3883,3 +3883,30 @@ int ge_p3_is_point_at_infinity_vartime(const ge_p3 *p) {
   // Y/Z = 0/0
   return 0;
 }
+
+/*
+Preconditions:
+  |h| bounded by 1.1*2^26,1.1*2^25,1.1*2^26,1.1*2^25,etc.
+
+Since fe_add and fe_sub enforce the following conditions:
+
+fe_add & fe_sub preconditions:
+   |f| bounded by 1.1*2^25,1.1*2^24,1.1*2^25,1.1*2^24,etc.
+   |g| bounded by 1.1*2^25,1.1*2^24,1.1*2^25,1.1*2^24,etc.
+
+fe_add & fe_sub postconditions:
+   |h| bounded by 1.1*2^26,1.1*2^25,1.1*2^26,1.1*2^25,etc.
+
+We sometimes need to "reduce" field elems when they are in the poscondition's
+larger domain to match the precondition domain. This way we can take the output
+of fe_add or fe_sub and use it as input to another call to fe_add or fe_sub.
+
+We reduce by converting the field elem to its byte repr, then re-deriving the
+field elem from the byte repr.
+*/
+int fe_reduce_vartime(fe reduced_f, const fe f)
+{
+  unsigned char f_bytes[32];
+  fe_tobytes(f_bytes, f);
+  return fe_frombytes_vartime(reduced_f, f_bytes);
+}

--- a/src/crypto/crypto-ops.c
+++ b/src/crypto/crypto-ops.c
@@ -3904,9 +3904,84 @@ of fe_add or fe_sub and use it as input to another call to fe_add or fe_sub.
 We reduce by converting the field elem to its byte repr, then re-deriving the
 field elem from the byte repr.
 */
-int fe_reduce_vartime(fe reduced_f, const fe f)
+void fe_reduce(fe reduced_f, const fe f)
 {
-  unsigned char f_bytes[32];
-  fe_tobytes(f_bytes, f);
-  return fe_frombytes_vartime(reduced_f, f_bytes);
+#define D24 (1l << 24)
+#define D25 (1l << 25)
+
+  int32_t f0 = f[0];
+  int32_t f1 = f[1];
+  int32_t f2 = f[2];
+  int32_t f3 = f[3];
+  int32_t f4 = f[4];
+  int32_t f5 = f[5];
+  int32_t f6 = f[6];
+  int32_t f7 = f[7];
+  int32_t f8 = f[8];
+  int32_t f9 = f[9];
+  int32_t q;
+  int32_t carry0;
+  int32_t carry1;
+  int32_t carry2;
+  int32_t carry3;
+  int32_t carry4;
+  int32_t carry5;
+  int32_t carry6;
+  int32_t carry7;
+  int32_t carry8;
+  int32_t carry9;
+
+  /*
+  According to the C standard, the resulting value of right-shift of negative
+  signed integers is implementation-defined. Worse, left-shift of negative
+  signed integers triggers undefined behavior for some strange reason. So, this
+  code is not technically portable. However, both types of shifts are
+  well-defined in GCC as "arithmetic shifts", as well as other compilers aiming
+  to be compatible with GCC (e.g. Clang). In practice, Visual Studio will
+  *probably* also use arithmetic shifts for signed integers on major desktop
+  platforms. The rest of this file assumes arithmetic shifts, so we keep using
+  it here, but it's important to notice.
+  */
+
+  q = (19 * f9 + D24 + D24) >> 25;
+  q = (f0 + q + D25) >> 26;
+  q = (f1 + q + D24) >> 25;
+  q = (f2 + q + D25) >> 26;
+  q = (f3 + q + D24) >> 25;
+  q = (f4 + q + D25) >> 26;
+  q = (f5 + q + D24) >> 25;
+  q = (f6 + q + D25) >> 26;
+  q = (f7 + q + D24) >> 25;
+  q = (f8 + q + D25) >> 26;
+  q = (f9 + q + D24) >> 25;
+
+  /* Goal: Output f-(2^255-19)q, which is between 0 and 2^255-20. */
+  f0 += 19 * q;
+  /* Goal: Output h-2^255 q, which is between 0 and 2^255-20. */
+
+  carry0 = (f0 + D25) >> 26; f1 += carry0; f0 -= carry0 << 26;
+  carry1 = (f1 + D24) >> 25; f2 += carry1; f1 -= carry1 << 25;
+  carry2 = (f2 + D25) >> 26; f3 += carry2; f2 -= carry2 << 26;
+  carry3 = (f3 + D24) >> 25; f4 += carry3; f3 -= carry3 << 25;
+  carry4 = (f4 + D25) >> 26; f5 += carry4; f4 -= carry4 << 26;
+  carry5 = (f5 + D24) >> 25; f6 += carry5; f5 -= carry5 << 25;
+  carry6 = (f6 + D25) >> 26; f7 += carry6; f6 -= carry6 << 26;
+  carry7 = (f7 + D24) >> 25; f8 += carry7; f7 -= carry7 << 25;
+  carry8 = (f8 + D25) >> 26; f9 += carry8; f8 -= carry8 << 26;
+  carry9 = (f9 + D24) >> 25;               f9 -= carry9 << 25;
+                  /* f10 = carry9 */
+
+  reduced_f[0] = f0;
+  reduced_f[1] = f1;
+  reduced_f[2] = f2;
+  reduced_f[3] = f3;
+  reduced_f[4] = f4;
+  reduced_f[5] = f5;
+  reduced_f[6] = f6;
+  reduced_f[7] = f7;
+  reduced_f[8] = f8;
+  reduced_f[9] = f9;
+
+#undef D24
+#undef D25
 }

--- a/src/crypto/crypto-ops.h
+++ b/src/crypto/crypto-ops.h
@@ -168,3 +168,5 @@ void fe_mul(fe out, const fe, const fe);
 void fe_0(fe h);
 
 int ge_p3_is_point_at_infinity_vartime(const ge_p3 *p);
+
+int fe_reduce_vartime(fe reduced_f, const fe f);

--- a/src/crypto/crypto-ops.h
+++ b/src/crypto/crypto-ops.h
@@ -88,6 +88,7 @@ void ge_double_scalarmult_base_vartime_p3(ge_p3 *, const unsigned char *, const 
 
 extern const fe fe_sqrtm1;
 extern const fe fe_d;
+int fe_frombytes_vartime(fe, const unsigned char *);
 int ge_frombytes_vartime(ge_p3 *, const unsigned char *);
 
 /* From ge_p1p1_to_p2.c */

--- a/src/crypto/crypto-ops.h
+++ b/src/crypto/crypto-ops.h
@@ -169,4 +169,4 @@ void fe_0(fe h);
 
 int ge_p3_is_point_at_infinity_vartime(const ge_p3 *p);
 
-int fe_reduce_vartime(fe reduced_f, const fe f);
+void fe_reduce(fe reduced_f, const fe f);

--- a/tests/performance_tests/fe_reduce.h
+++ b/tests/performance_tests/fe_reduce.h
@@ -1,0 +1,92 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+
+extern "C"
+{
+#include "crypto/crypto-ops.h"
+}
+#include "crypto/crypto.h"
+
+namespace 
+{
+static inline void fe_reduce_simple(fe reduced, const fe f)
+{
+    unsigned char f_bytes[32];
+    fe_tobytes(f_bytes, f);
+    const int r = fe_frombytes_vartime(reduced, f_bytes);
+    (void) r;
+    assert(0 == r);
+}
+} //anonymous namespace
+
+template <bool fast_fe_reduce>
+class test_fe_reduce
+{
+public:
+  static const size_t loop_count = 10000;
+  static const size_t subloop_count = 10000;
+
+  bool init()
+  {
+    // generate random fe
+    for (int i = 0; i < 10; ++i)
+    {
+        const int32_t limit = ((i & 1) ? (1 << 25) : (1 << 26)) * 11 / 10;
+        this->a[i] = crypto::rand_range(-limit, limit);
+    }
+
+    return true;
+  }
+
+  bool test()
+  {
+    fe res;
+
+    for (size_t i = 0; i < subloop_count; ++i)
+    {
+        if constexpr (fast_fe_reduce)
+        {
+            fe_reduce(res, this->a);
+        }
+        else
+        {
+            fe_reduce_simple(res, this->a);
+        }
+    }
+
+    return true;
+  }
+
+protected:
+  fe a;
+};

--- a/tests/performance_tests/main.cpp
+++ b/tests/performance_tests/main.cpp
@@ -43,6 +43,7 @@
 #include "derive_public_key.h"
 #include "derive_secret_key.h"
 #include "derive_view_tag.h"
+#include "fe_reduce.h"
 #include "ge_frombytes_vartime.h"
 #include "ge_tobytes.h"
 #include "generate_key_derivation.h"
@@ -198,6 +199,8 @@ int main(int argc, char** argv)
   TEST_PERFORMANCE0(filter, p, test_generate_key_image);
   TEST_PERFORMANCE0(filter, p, test_derive_public_key);
   TEST_PERFORMANCE0(filter, p, test_derive_secret_key);
+  TEST_PERFORMANCE1(filter, p, test_fe_reduce, false);
+  TEST_PERFORMANCE1(filter, p, test_fe_reduce, true);
   TEST_PERFORMANCE0(filter, p, test_ge_frombytes_vartime);
   TEST_PERFORMANCE0(filter, p, test_ge_tobytes);
   TEST_PERFORMANCE0(filter, p, test_generate_keypair);

--- a/tests/unit_tests/crypto.cpp
+++ b/tests/unit_tests/crypto.cpp
@@ -26,18 +26,21 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include "crypto/crypto.h"
+#include <boost/numeric/conversion/cast.hpp>
 #include <cstdint>
+#include <cstring>
 #include <gtest/gtest.h>
-#include <memory>
 #include <sstream>
 #include <string>
+
+#include <boost/multiprecision/cpp_int.hpp>
 
 extern "C"
 {
 #include "crypto/crypto-ops.h"
 }
 #include "crypto/generators.h"
-#include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "cryptonote_basic/merge_mining.h"
 #include "ringct/rctOps.h"
 #include "ringct/rctTypes.h"
@@ -344,4 +347,111 @@ TEST(Crypto, generator_consistency)
 
   // ringct/rctTypes.h
   ASSERT_TRUE(memcmp(H.data, rct::H.bytes, 32) == 0);
+}
+
+static bool fe_is_reduced(const fe f)
+{
+  static constexpr int32_t limit_even = (1 << 25) * 11 / 10;
+  static constexpr int32_t limit_odd = (1 << 24) * 11 / 10;
+  for (int i = 0; i < 10; ++i)
+  {
+    const int32_t limit = (i & 1) ? limit_odd : limit_even;
+    if (f[i] < -limit || f[i] > limit)
+      return false;
+  }
+  return true;
+}
+
+static void fe_frombytes_from64(fe f, const int64_t x)
+{
+  boost::multiprecision::int256_t x_256 = x;
+  if (x_256 < 0)
+  {
+    boost::multiprecision::int256_t q = 1;
+    q <<= 254;
+    q -= 10;
+    q <<= 1;
+    q += 1;
+    x_256 += q;
+  }
+  assert(x_256 >= 0);
+  assert(!(x_256 >> 255));
+  unsigned char x_bytes[32]{};
+  for (int i = 0; i < 32; ++i)
+  {
+    x_bytes[i] = boost::numeric_cast<unsigned char>(x_256 & 255);
+    x_256 >>= 8;
+  }
+  const int r = fe_frombytes_vartime(f, x_bytes);
+  (void) r;
+  assert(r == 0);
+}
+
+TEST(Crypto, fe_reduce_simple_reprs)
+{
+  static constexpr int MIN = -400;
+  static constexpr int MAX = 400;
+
+  for (int a = MIN; a <= MAX; ++a)
+  {
+    for (int b = MIN; b <= MAX; ++b)
+    {
+      /*
+      For each (a, b) in [MIN, MAX], check that fe_reduce(a + b) == a + b,
+      after converting to byte representation.
+      */
+      fe a_fe;
+      fe b_fe;
+      fe c_fe;
+      fe c_fe_reduced;
+      unsigned char c_bytes_1[32];
+      unsigned char c_bytes_2[32];
+      fe_frombytes_from64(a_fe, a);
+      fe_frombytes_from64(b_fe, b);
+      fe_add(c_fe, a_fe, b_fe);
+      fe_reduce(c_fe_reduced, c_fe);
+      ASSERT_TRUE(fe_is_reduced(c_fe_reduced));
+      fe_tobytes(c_bytes_1, c_fe);
+      fe_tobytes(c_bytes_2, c_fe_reduced);
+      ASSERT_EQ(0, memcmp(c_bytes_1, c_bytes_2, 32));
+
+      // UNIT TEST ONLY: Check fe_frombytes_from64()
+      {
+        fe c_fe_from64;
+        const int c = a + b;
+        fe_frombytes_from64(c_fe_from64, c);
+        fe_tobytes(c_bytes_2, c_fe_from64);
+        ASSERT_EQ(0, memcmp(c_bytes_1, c_bytes_2, 32));
+      }
+    }
+  }
+}
+
+TEST(Crypto, fe_reduce_random_reprs)
+{
+  static constexpr int32_t repr_limit_even = (1 << 26) * 11 / 10;
+  static constexpr int32_t repr_limit_odd = (1 << 25) * 11 / 10;
+  static constexpr int n_tries = 100000;
+
+  for (int i = 0; i < n_tries; ++i)
+  {
+    fe a;
+    fe a_reduced;
+    unsigned char a_bytes[32];
+    unsigned char a_reduced_bytes[32];
+
+    // Generate a random fe representation
+    for (int j = 0; j < 10; ++j)
+    {
+      const int32_t repr_limit = (j & 1) ? repr_limit_odd : repr_limit_even;
+      a[j] = crypto::rand_range(-repr_limit, repr_limit);
+    }
+
+    // Check that tobytes(a) == tobytes(reduced(a))
+    fe_reduce(a_reduced, a);
+    ASSERT_TRUE(fe_is_reduced(a_reduced));
+    fe_tobytes(a_bytes, a);
+    fe_tobytes(a_reduced_bytes, a_reduced);
+    ASSERT_EQ(0, memcmp(a_bytes, a_reduced_bytes, 32));
+  }
 }


### PR DESCRIPTION
Results on Intel i7-1355U, Linux 6.19.9-1-cachyos, GCC 15.2.1:

```
test_fe_reduce<false> (10000 calls) - OK: 169 µs/call
test_fe_reduce<true> (10000 calls) - OK: 106 µs/call
```

AKA `fe_reduce()` in this PR has a 40% speedup. Also, it's constant-time. Not anything crazy, and `fe_reduce()` doesn't take that much time anyways.