### PR TITLE
`fe_equals` constant time + `fe_batch_invert` fail on 0 value

### DIFF
--- a/src/crypto/crypto-ops.c
+++ b/src/crypto/crypto-ops.c
@@ -29,6 +29,7 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include <assert.h>
+#include <sodium/crypto_verify_32.h>
 #include <stdint.h>
 
 #include "warnings.h"
@@ -319,19 +320,25 @@ int fe_equals(const fe a, const fe b) {
   unsigned char b_bytes[32];
   fe_tobytes(a_bytes, a);
   fe_tobytes(b_bytes, b);
+  return crypto_verify_32(a_bytes, b_bytes) == 0;
+}
 
-  int r = 1;
-  for (int i = 0; i < 32; ++i) {
-    r &= a_bytes[i] == b_bytes[i];
-  }
-  return r;
+/* From fe_isnonzero.c, modified */
+
+static int fe_isnonzero(const fe f) {
+  unsigned char s[32];
+  fe_tobytes(s, f);
+  return (((int) (s[0] | s[1] | s[2] | s[3] | s[4] | s[5] | s[6] | s[7] | s[8] |
+    s[9] | s[10] | s[11] | s[12] | s[13] | s[14] | s[15] | s[16] | s[17] |
+    s[18] | s[19] | s[20] | s[21] | s[22] | s[23] | s[24] | s[25] | s[26] |
+    s[27] | s[28] | s[29] | s[30] | s[31]) - 1) >> 8) + 1;
 }
 
 // Montgomery's trick
 // https://iacr.org/archive/pkc2004/29470042/29470042.pdf 2.2
-void fe_batch_invert(fe* __restrict out, const fe* __restrict in, const int n) {
+int fe_batch_invert(fe* __restrict out, const fe* __restrict in, const unsigned int n) {
   if (n == 0) {
-    return;
+    return 0;
   }
 
   assert(out);
@@ -340,20 +347,26 @@ void fe_batch_invert(fe* __restrict out, const fe* __restrict in, const int n) {
 
   // Step 1: collect initial muls
   fe_copy(out[0], in[0]);
-  for (int i = 1; i < n; ++i) {
+  for (unsigned int i = 1; i < n; ++i) {
     fe_mul(out[i], out[i-1], in[i]);
   }
 
   // Step 2: get the inverse of all elems multiplied together
+  if (!fe_isnonzero(out[n-1])) {
+    // Don't divide by 0
+    return -1;
+  }
   fe a;
   fe_invert(a, out[n-1]);
 
   // Step 3: get each inverse
-  for (int i = n; i > 1; --i) {
+  for (unsigned int i = n; i > 1; --i) {
     fe_mul(out[i-1], a, out[i-2]);
     fe_mul(a, a, in[i-1]);
   }
   fe_copy(out[0], a);
+
+  return 0;
 }
 
 /* From fe_isnegative.c */
@@ -370,17 +383,6 @@ static int fe_isnegative(const fe f) {
   unsigned char s[32];
   fe_tobytes(s, f);
   return s[0] & 1;
-}
-
-/* From fe_isnonzero.c, modified */
-
-static int fe_isnonzero(const fe f) {
-  unsigned char s[32];
-  fe_tobytes(s, f);
-  return (((int) (s[0] | s[1] | s[2] | s[3] | s[4] | s[5] | s[6] | s[7] | s[8] |
-    s[9] | s[10] | s[11] | s[12] | s[13] | s[14] | s[15] | s[16] | s[17] |
-    s[18] | s[19] | s[20] | s[21] | s[22] | s[23] | s[24] | s[25] | s[26] |
-    s[27] | s[28] | s[29] | s[30] | s[31]) - 1) >> 8) + 1;
 }
 
 /* From fe_mul.c */

--- a/src/crypto/crypto-ops.h
+++ b/src/crypto/crypto-ops.h
@@ -171,8 +171,10 @@ int fe_equals(const fe a, const fe b);
 
 Unlike other crypto functions, `out` and `in` memory sections CANNOT be aliased.
 If `out` and `in` overlap, it will cause undefined output.
+
+No 0 fe's are expected for `in`, otherwise fails.
 **/
-void fe_batch_invert(fe* __restrict out, const fe* __restrict in, const int n);
+int fe_batch_invert(fe* __restrict out, const fe* __restrict in, const unsigned int n);
 void fe_mul(fe out, const fe, const fe);
 void fe_0(fe h);
 

--- a/tests/unit_tests/crypto.cpp
+++ b/tests/unit_tests/crypto.cpp
@@ -365,7 +365,7 @@ TEST(Crypto, batch_inversion)
   for (std::size_t n_elems = 1; n_elems <= MAX_TEST_ELEMS; ++n_elems)
   {
     std::unique_ptr<fe[]> batch_inverted = std::make_unique<fe[]>(n_elems);
-    fe_batch_invert(batch_inverted.get(), init_elems.get(), n_elems);
+    ASSERT_EQ(fe_batch_invert(batch_inverted.get(), init_elems.get(), n_elems), 0);
     for (std::size_t i = 0; i < n_elems; ++i)
       ASSERT_EQ(fe_equals(batch_inverted[i], norm_inverted[i]), 1);
   }
@@ -393,6 +393,21 @@ TEST(Crypto, batch_inversion_touching)
     fe_invert(inv_simple, vals[i]);
     ASSERT_EQ(1, fe_equals(inv_simple, vals[2 + i]));
   }
+}
+
+TEST(Crypto, batch_invert_zero)
+{
+  const std::size_t TEST_ELEMS = 2;
+  std::unique_ptr<fe[]> init_elems = std::make_unique<fe[]>(TEST_ELEMS);
+
+  // Init test elems
+  const cryptonote::keypair kp = cryptonote::keypair::generate(hw::get_device("default"));
+  ASSERT_EQ(fe_frombytes_vartime(init_elems[0], (unsigned char*)kp.pub.data), 0);
+  fe_0(init_elems[1]);
+
+  // Do the batch inversion, should fail
+  std::unique_ptr<fe[]> batch_inverted = std::make_unique<fe[]>(TEST_ELEMS);
+  ASSERT_EQ(fe_batch_invert(batch_inverted.get(), init_elems.get(), TEST_ELEMS), -1);
 }
 
 TEST(Crypto, fe_equals)


### PR DESCRIPTION
1. Use libsodium's `crypto_verify_32` for constant time `fe_equals` (we already link it in libcncrypto)
2. `fe_batch_invert` returns -1 if it's passed in a 0 value to avoid allowing unexpected behavior.
3. Use `unsigned int` for n to prevent negative n.