### PR TITLE
Torsion clear remediation (Cypher Stack audit + boog900 comment)

### DIFF
--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -335,7 +335,7 @@ namespace crypto {
 
   static const ec_point EC_I = {1};
 
-  static const ec_point EC_INV_EIGHT = {{
+  static const ec_scalar EC_INV_EIGHT = {{
       static_cast<char>(0x79), static_cast<char>(0x2f), static_cast<char>(0xdc), static_cast<char>(0xe2),
       static_cast<char>(0x29), static_cast<char>(0xe5), static_cast<char>(0x06), static_cast<char>(0x61),
       static_cast<char>(0xd0), static_cast<char>(0xda), static_cast<char>(0x1c), static_cast<char>(0x7d),

--- a/src/fcmp_pp/fcmp_pp_crypto.cpp
+++ b/src/fcmp_pp/fcmp_pp_crypto.cpp
@@ -58,8 +58,6 @@ bool get_valid_torsion_cleared_point(const crypto::ec_point &point, crypto::ec_p
     ge_p3 p3;
     if (ge_frombytes_vartime(&p3, to_bytes(point)) != 0)
         return false;
-    if (mul8_is_identity(p3))
-        return false;
     torsion_cleared_out = fcmp_pp::clear_torsion(p3);
     if (torsion_cleared_out == crypto::EC_I)
         return false;

--- a/src/fcmp_pp/fcmp_pp_crypto.cpp
+++ b/src/fcmp_pp/fcmp_pp_crypto.cpp
@@ -31,7 +31,7 @@
 namespace fcmp_pp
 {
 //----------------------------------------------------------------------------------------------------------------------
-bool mul8_is_identity(const ge_p3 &point) {
+bool mul8_is_identity_vartime(const ge_p3 &point) {
     ge_p2 point_ge_p2;
     ge_p3_to_p2(&point_ge_p2, &point);
     ge_p1p1 point_mul8;
@@ -41,7 +41,7 @@ bool mul8_is_identity(const ge_p3 &point) {
     return ge_p3_is_point_at_infinity_vartime(&point_mul8_p3);
 }
 //----------------------------------------------------------------------------------------------------------------------
-crypto::ec_point clear_torsion(const ge_p3 &point) {
+crypto::ec_point clear_torsion_vartime(const ge_p3 &point) {
     // mul by inv 8, then mul by 8
     ge_p2 point_inv_8;
     ge_scalarmult(&point_inv_8, to_bytes(crypto::EC_INV_EIGHT), &point);
@@ -54,11 +54,11 @@ crypto::ec_point clear_torsion(const ge_p3 &point) {
     return k_out;
 }
 //----------------------------------------------------------------------------------------------------------------------
-bool get_valid_torsion_cleared_point(const crypto::ec_point &point, crypto::ec_point &torsion_cleared_out) {
+bool get_valid_torsion_cleared_point_vartime(const crypto::ec_point &point, crypto::ec_point &torsion_cleared_out) {
     ge_p3 p3;
     if (ge_frombytes_vartime(&p3, to_bytes(point)) != 0)
         return false;
-    torsion_cleared_out = fcmp_pp::clear_torsion(p3);
+    torsion_cleared_out = fcmp_pp::clear_torsion_vartime(p3);
     if (torsion_cleared_out == crypto::EC_I)
         return false;
     return true;

--- a/src/fcmp_pp/fcmp_pp_crypto.h
+++ b/src/fcmp_pp/fcmp_pp_crypto.h
@@ -38,9 +38,9 @@ namespace fcmp_pp
 {
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
-bool mul8_is_identity(const ge_p3 &point);
-crypto::ec_point clear_torsion(const ge_p3 &point);
-bool get_valid_torsion_cleared_point(const crypto::ec_point &point, crypto::ec_point &torsion_cleared_out);
+bool mul8_is_identity_vartime(const ge_p3 &point);
+crypto::ec_point clear_torsion_vartime(const ge_p3 &point);
+bool get_valid_torsion_cleared_point_vartime(const crypto::ec_point &point, crypto::ec_point &torsion_cleared_out);
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 }//namespace fcmp_pp

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -1628,7 +1628,7 @@ namespace rct {
           {
             const crypto::ec_point &point = rct::rct2pt(pts[i]);
             crypto::ec_point torsion_cleared_point;
-            if (!fcmp_pp::get_valid_torsion_cleared_point(point, torsion_cleared_point))
+            if (!fcmp_pp::get_valid_torsion_cleared_point_vartime(point, torsion_cleared_point))
             {
               torsion_free[i] = false;
               return;

--- a/tests/unit_tests/crypto.cpp
+++ b/tests/unit_tests/crypto.cpp
@@ -357,7 +357,7 @@ TEST(Crypto, ec_constants_rct_parity)
 
 #define CHECK_CLEARED(k, cleared) \
   crypto::ec_point cleared2; \
-  const bool r = fcmp_pp::get_valid_torsion_cleared_point(rct::rct2pt(k), cleared2); \
+  const bool r = fcmp_pp::get_valid_torsion_cleared_point_vartime(rct::rct2pt(k), cleared2); \
   ASSERT_TRUE(r); \
   ASSERT_EQ(cleared, cleared2);
 
@@ -371,8 +371,8 @@ TEST(Crypto, torsion_check_pass_random)
     ASSERT_EQ(ge_frombytes_vartime(&x, (const unsigned char*)kp.pub.data), 0);
     const rct::key k = rct::pk2rct(kp.pub);
     ASSERT_TRUE(rct::isInMainSubgroup(k));
-    ASSERT_FALSE(fcmp_pp::mul8_is_identity(x));
-    const crypto::ec_point cleared = fcmp_pp::clear_torsion(x);
+    ASSERT_FALSE(fcmp_pp::mul8_is_identity_vartime(x));
+    const crypto::ec_point cleared = fcmp_pp::clear_torsion_vartime(x);
     ASSERT_EQ(rct::rct2pt(k), cleared);
     CHECK_CLEARED(k, cleared);
     pts.emplace_back(k);
@@ -396,8 +396,8 @@ TEST(Crypto, torsion_check_pass_hardcoded)
     ge_p3 x;
     ASSERT_EQ(ge_frombytes_vartime(&x, k.bytes), 0);
     ASSERT_TRUE(rct::isInMainSubgroup(k));
-    ASSERT_FALSE(fcmp_pp::mul8_is_identity(x));
-    const crypto::ec_point cleared = fcmp_pp::clear_torsion(x);
+    ASSERT_FALSE(fcmp_pp::mul8_is_identity_vartime(x));
+    const crypto::ec_point cleared = fcmp_pp::clear_torsion_vartime(x);
     ASSERT_EQ(rct::rct2pt(k), cleared);
     CHECK_CLEARED(k, cleared);
     pts.emplace_back(k);
@@ -412,8 +412,8 @@ TEST(Crypto, torsion_check_torsioned_point)
   ge_p3 x;
   ASSERT_EQ(ge_frombytes_vartime(&x, k.bytes), 0);
   ASSERT_FALSE(rct::isInMainSubgroup(k));
-  ASSERT_FALSE(fcmp_pp::mul8_is_identity(x));
-  const crypto::ec_point cleared = fcmp_pp::clear_torsion(x);
+  ASSERT_FALSE(fcmp_pp::mul8_is_identity_vartime(x));
+  const crypto::ec_point cleared = fcmp_pp::clear_torsion_vartime(x);
   ASSERT_NE(rct::rct2pt(k), cleared);
   CHECK_CLEARED(k, cleared);
   ASSERT_FALSE(rct::verPointsForTorsion({k}));
@@ -427,8 +427,8 @@ TEST(Crypto, genesis_tx_output_torsion)
   ge_p3 x;
   ASSERT_EQ(ge_frombytes_vartime(&x, k.bytes), 0);
   EXPECT_FALSE(rct::isInMainSubgroup(k));
-  ASSERT_FALSE(fcmp_pp::mul8_is_identity(x));
-  const crypto::ec_point cleared = fcmp_pp::clear_torsion(x);
+  ASSERT_FALSE(fcmp_pp::mul8_is_identity_vartime(x));
+  const crypto::ec_point cleared = fcmp_pp::clear_torsion_vartime(x);
   ASSERT_NE(rct::rct2pt(k), cleared);
   CHECK_CLEARED(k, cleared);
   ASSERT_FALSE(rct::verPointsForTorsion({k}));


### PR DESCRIPTION
- Removes redundant check for mul8 is identity in torsion clear
  - Pointed out by Cypher Stack (CS) in [6.4.2](https://github.com/cypherstack/fcmp-impl-audit/blob/d7de33d08c48a3c249629e47f71ea72c938a3404/FCMP_Code_Implementation_Audit.pdf) and by @boog900.
- Suffix vartime functions with `_vartime`.
  - CS [6.5](https://github.com/cypherstack/fcmp-impl-audit/blob/d7de33d08c48a3c249629e47f71ea72c938a3404/FCMP_Code_Implementation_Audit.pdf).
- Correctly use scalar type for `EC_INV_EIGHT`.
  - CS [6.3.2](https://github.com/cypherstack/fcmp-impl-audit/blob/d7de33d08c48a3c249629e47f71ea72c938a3404/FCMP_Code_Implementation_Audit.pdf)